### PR TITLE
#156981666 Reimplement event/center posting to use client side image upload

### DIFF
--- a/Client/src/components/manageDetailsHeader.js
+++ b/Client/src/components/manageDetailsHeader.js
@@ -70,7 +70,7 @@ class ManageDetails extends Component {
         const type = currentPage === 'manageEvent' ? 'events' : 'centers';
         return `${apiLink}/api/v1/${type}/${param}/?token=${
           JSON.parse(localStorage.token).value
-        }&file=${resource.picture}`;
+        }&file=${resource.publicId}`;
       };
       const url = urlGenerator();
       axios

--- a/Client/src/components/sidebarComponent.js
+++ b/Client/src/components/sidebarComponent.js
@@ -28,6 +28,7 @@ export class Sidebar extends Component {
   }
   changeLocation(url) {
     history.push(url);
+    $('#myModalSidebar').modal('hide');
   }
   render() {
     const content = (

--- a/Client/src/reusables.js
+++ b/Client/src/reusables.js
@@ -14,7 +14,7 @@ export const logout = (id, history) => {
   history.push('/');
 };
 
-export const apiLink = 'https://eventmanageronline.herokuapp.com'; // 'http://localhost:8080';
+export const apiLink = 'https://eventmanageronline.herokuapp.com'; // 'http://localhost:8000';
 
 export const getCenters = (axios, populateCenters) => {
   axios

--- a/Server/app.js
+++ b/Server/app.js
@@ -33,7 +33,7 @@ app.use('/api/v1/centers', centers);
 app.use('/api/v1/users', users);
 app.use('/api/v1/facilities', facilities);
 
-const port = process.env.PORT || 8080;
+const port = process.env.PORT || 8000;
 const server = http.createServer(app);
 
 server.listen(port, () => {

--- a/Server/middlewares/authenticator.js
+++ b/Server/middlewares/authenticator.js
@@ -1,5 +1,12 @@
 ﻿import jwt from 'jsonwebtoken';
 require('dotenv').config();
+import cloudinary from 'cloudinary';
+
+cloudinary.config({
+  cloud_name: 'eventmanager',
+  api_key: '789891965151338',
+  api_secret: 'ynezeVbgUnGIfNYKj19GvyrflSI',
+});
 
 class Authenticator {
   constructor() {
@@ -7,14 +14,18 @@ class Authenticator {
     this.Verify = (req, res, next) => {
       const token = req.body.token || req.headers['x-token'] || req.query.token;
       if (!token) {
-        return res.status(401).json({ status: 'error', message: 'Unauthorized' });
+        return cloudinary.v2.uploader.destroy(req.body.publicId, () =>
+          res.status(401).json({ status: 'error', message: 'Unauthorized' })
+        );
       }
       jwt.verify(token, this.key, (error, decoded) => {
         if (error) {
-          return res.status(403).json({
-            status: 'error',
-            message: 'Token could not be authenticated'
-          });
+          return cloudinary.v2.uploader.destroy(req.body.publicId, () =>
+            res.status(403).json({
+              status: 'error',
+              message: 'Token could not be authenticated',
+            })
+          );
         }
         req.decoded = decoded;
         next();

--- a/Server/middlewares/validator.js
+++ b/Server/middlewares/validator.js
@@ -1,11 +1,18 @@
-﻿class Validator {
+﻿import cloudinary from 'cloudinary';
+
+cloudinary.config({
+  cloud_name: 'eventmanager',
+  api_key: '789891965151338',
+  api_secret: 'ynezeVbgUnGIfNYKj19GvyrflSI',
+});
+
+class Validator {
   constructor(model, context) {
     this.model = model;
     this.context = context;
     this.invalidParameter = {};
     this.verificationError = {};
     this.errorMessage = (msg, res) => this.response(res, 'err', 400, msg);
-
     this.confirmParams = (req, res) => {
       if (isNaN(req.params.id)) {
         this.invalidParameter = this.errorMessage('invalid parameter', res);
@@ -97,13 +104,21 @@
         this.verificationError = this.errorMessage('Invalid center selected', res);
       } else {
         next();
+        return this.verificationError;
       }
-      return this.verificationError;
+      return cloudinary.v2.uploader.destroy(req.body.publicId, () => this.verificationError);
     };
 
     this.verifyCenter = (req, res, next) => {
       // validate center name
-      const { name, address, location, capacity, price, availability } = req.body;
+      const {
+        name,
+        address,
+        location,
+        capacity,
+        price,
+        availability,
+      } = req.body;
       if (
         name === undefined ||
         typeof name !== 'string' ||
@@ -162,8 +177,9 @@
         );
       } else {
         next();
+        return this.verificationError;
       }
-      return this.verificationError;
+      return cloudinary.v2.uploader.destroy(req.body.publicId, () => this.verificationError);
     };
     this.verifyUser = (req, res, context, next) => {
       if (context === 'signup') {

--- a/Server/migrations/20171126132418-create-centers.js
+++ b/Server/migrations/20171126132418-create-centers.js
@@ -24,7 +24,7 @@ module.exports = {
     picture: {
       type: Sequelize.STRING, // Image url
     },
-    public_id: {
+    publicId: {
       type: Sequelize.STRING, // cloudinary image public_id
     },
     availability: {

--- a/Server/migrations/20171126133851-create-events.js
+++ b/Server/migrations/20171126133851-create-events.js
@@ -20,7 +20,7 @@ module.exports = {
         type: Sequelize.STRING, // image url
         allowNull: true,
       },
-      public_id: {
+      publicId: {
         type: Sequelize.STRING, // cloudinary image public_id
         allowNull: true,
       },

--- a/Server/models/centers.js
+++ b/Server/models/centers.js
@@ -6,7 +6,7 @@ module.exports = (sequelize, DataTypes) => {
     capacity: DataTypes.INTEGER,
     price: DataTypes.INTEGER,
     picture: DataTypes.STRING, // Image url
-    public_id: DataTypes.STRING, // cloudinary image public_id
+    publicId: DataTypes.STRING, // cloudinary image public_id
     availability: DataTypes.STRING,
     userId: DataTypes.INTEGER,
   });

--- a/Server/models/events.js
+++ b/Server/models/events.js
@@ -7,7 +7,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING, // image url
       allowNull: true,
     },
-    public_id: {
+    publicId: {
       type: DataTypes.STRING, // cloudinary image public_id
       allowNull: true,
     },

--- a/Server/routers/centerRouter.js
+++ b/Server/routers/centerRouter.js
@@ -2,7 +2,6 @@
 import Centers from '../controllers/centerController';
 import Val from '../middlewares/validator';
 import Auth from '../middlewares/authenticator';
-import multer from 'multer';
 import cloudinary from 'cloudinary';
 
 cloudinary.config({
@@ -10,13 +9,12 @@ cloudinary.config({
   api_key: '789891965151338',
   api_secret: 'ynezeVbgUnGIfNYKj19GvyrflSI',
 });
-const storage = multer.memoryStorage();
-const upload = multer({ storage });
+
 const Validator = new Val('centers');
 const router = express.Router();
 
-router.post('/', upload.single('picture'), Validator.verify, Auth.Verify, Centers.addCenter);
-router.put('/:id', upload.single('picture'), Validator.verify, Auth.Verify, Centers.modifyCenter);
+router.post('/', Validator.verify, Auth.Verify, Centers.addCenter);
+router.put('/:id', Validator.verify, Auth.Verify, Centers.modifyCenter);
 router.get('/', Centers.getAllCenters); // no validation required
 router.get('/:id', Centers.getCenterDetails); // no validation required
 

--- a/Server/routers/eventRouter.js
+++ b/Server/routers/eventRouter.js
@@ -2,7 +2,6 @@
 import Events from '../controllers/eventController';
 import Val from '../middlewares/validator';
 import Auth from '../middlewares/authenticator';
-import multer from 'multer';
 import cloudinary from 'cloudinary';
 
 cloudinary.config({
@@ -10,13 +9,11 @@ cloudinary.config({
   api_key: '789891965151338',
   api_secret: 'ynezeVbgUnGIfNYKj19GvyrflSI',
 });
-const storage = multer.memoryStorage();
-const upload = multer({ storage });
 const Validator = new Val('events');
 const router = express.Router();
 
-router.post('/', upload.single('picture'), Validator.verify, Auth.Verify, Events.addEvent);
-router.put('/:id', upload.single('picture'), Validator.verify, Auth.Verify, Events.modifyEvent);
+router.post('/', Validator.verify, Auth.Verify, Events.addEvent);
+router.put('/:id', Validator.verify, Auth.Verify, Events.modifyEvent);
 router.delete('/:id', Auth.Verify, Events.deleteEvent);
 router.get('/', Events.getEvents);
 router.get('/:id', Events.getEventDetails); // no validation required


### PR DESCRIPTION
#### What does this PR do?
Reimplement event/center posting to use client side image upload

#### Description of Task to be completed?
1. Modify addCenter component to implement clientside image upload before server API call
2. Modify addEvent component to implement clientside image upload before server API call
3. Implement functionality to hide sidebar on navigation click
4. Modify center controller to not use cloudinary file upload in center adding and update
5. Modify event controller to not use cloudinary file upload in center adding and update
6. Use query to pass and obtain publicId of event upon deletion
7. Modify error response in eventController, centerController, validator and authenticator to first delete uploaded image from cloudinary
8. Change public_id field in even and center models to publicId
9. Eliminate multer implementation for file-upload in event and center router
10. Change event and center data format to be sent from client from formData to json

#### How should this be manually tested?
on terminal, run command:
1. `npm run start`, then run:
2. `npm run client` (on another console)
3. login to the client app and add/edit event/center with image upload
4. check that transaction was successful without error

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories? (If applicable)
[#156981666](https://www.pivotaltracker.com/story/show/156981666)

#### Screenshots (If applicable)
None