### PR TITLE
#158759549 Implement server side feedback from LF

### DIFF
--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -17,7 +17,7 @@ cloudinary.config(cloudinaryConfig);
 const model = models.Centers;
 
 const include = [
-  { model: models.Events, as: 'events' },
+  { model: models.Events, as: 'events', limit: 2 },
   { model: models.Facilities, as: 'facilities' },
   {
     model: models.Users,
@@ -58,17 +58,9 @@ class Centers {
   // modify a center
   modifyCenter(req, res) {
     if (confirmParams(req, res) === true) {
-      return model
-        .findAll({ where: { id: { $ne: req.params.id } } }) // findAll where id notEqual to param.id
-        .then(centers => {
-          const modifiedEntry = centerEntry(req);
-          function modifyCenter() {
-            const condition = { id: req.params.id, userId: req.decoded.id };
-            return update(req, res, model, modifiedEntry, condition, attributes, include);
-          }
-          return compareCenters(req, res, centers, modifyCenter);
-        })
-        .catch(error => errorResponseWithCloudinary(req, res, 500, error));
+      const modifiedEntry = centerEntry(req);
+      const condition = { id: req.params.id, userId: req.decoded.id };
+      return update(req, res, model, modifiedEntry, condition, attributes, include);
     }
     cloudinary.v2.uploader.destroy(req.body.publicId);
     return invalidParameter;

--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -41,7 +41,7 @@ class Events {
             if (center.availability === 'open') {
               return create(req, res, model, newEntry, attributes, include);
             }
-            return errorResponseWithCloudinary(req, res, 406, 'Selected center is unavailable');
+            return errorResponseWithCloudinary(req, res, 409, 'Selected center is unavailable');
           })
           .catch(() =>
             errorResponseWithCloudinary(req, res, 400, 'Center selected does not exist')
@@ -62,7 +62,7 @@ class Events {
               const condition = { id: req.params.id, userId: req.decoded.id };
               return update(req, res, model, modified, condition, attributes, include);
             }
-            return errorResponseWithCloudinary(req, res, 406, 'Selected center is unavailable');
+            return errorResponseWithCloudinary(req, res, 409, 'Selected center is unavailable');
           })
           .catch(() =>
             errorResponseWithCloudinary(req, res, 400, 'Center selected does not exist')
@@ -80,8 +80,8 @@ class Events {
         .destroy({ where: { id: req.params.id, userId: req.decoded.id } })
         .then(response => {
           if (response === 0) {
-            // Event does not exist or User not priviledged to delete
-            return restResponse(res, 'error', 401, 'Invalid transaction');
+            const message = 'Cannot delete unexisting or unauthorized item';
+            return restResponse(res, 'error', 401, message);
           }
           cloudinary.v2.uploader.destroy(req.query.file);
           return restResponse(res, 'success', 200, 'Successfully deleted');
@@ -120,7 +120,7 @@ class Events {
           if (!found) {
             return restResponse(res, 'error', 404, 'Event does not exist');
           } else if (found.center.userId !== req.decoded.id) {
-            return restResponse(res, 'error', 403, 'No proviledge to perform action');
+            return restResponse(res, 'error', 403, 'No priviledge to approve event');
           }
           return modifyEvent(req, res, model, found.centerId, found.date, then, found);
         })

--- a/server/middlewares/validator.js
+++ b/server/middlewares/validator.js
@@ -85,6 +85,7 @@ class Validator {
     if (!this.isSentence(title, 3, 99)) {
       const message = 'Event title should be within 4-99 characters';
       this.verificationError = validationErrorMessage(message, res);
+      // EXAMPLE: July 17, 2018
     } else if (isNaN(Date.parse(date)) || Date.parse(date) < Date.parse(today)) {
       this.verificationError = validationErrorMessage('Event has none or invalid date', res);
     } else if (!time || !this.formatTime(time)) {

--- a/server/tests/1 userRouterTests.js
+++ b/server/tests/1 userRouterTests.js
@@ -23,7 +23,7 @@ describe('Tests for EventManager application\n', () => {
         })
         .end((err, res) => {
           expect(res.body).to.be.an('object');
-          expect(res).to.have.status(406);
+          expect(res).to.have.status(409);
           done();
         });
     });

--- a/server/tests/2 centerRouterTests.js
+++ b/server/tests/2 centerRouterTests.js
@@ -8,7 +8,7 @@ chai.use(chaiHttp);
 /*
 describe('Tests for EventManager application\n', () => {
   describe('Tests for centerRouter\n', () => {
-    it('Should test for addCenter 406 response', (done) => {
+    it('Should test for addCenter 409 response', (done) => {
       chai.request(app)
         .post('/api/v1/centers')
         .send({
@@ -22,7 +22,7 @@ describe('Tests for EventManager application\n', () => {
           token: adminToken,
         })
         .end((err, res) => {
-          expect(res).to.have.status(406);
+          expect(res).to.have.status(409);
           expect(res.body.message).to.include('Same center already exists');
           done();
         });
@@ -138,7 +138,7 @@ describe('Tests for EventManager application\n', () => {
           done();
         });
     });
-    it('Should test for modifyCenter 406 response', (done) => {
+    it('Should test for modifyCenter 409 response', (done) => {
       chai.request(app)
         .put('/api/v1/centers/1')
         .send({
@@ -152,7 +152,7 @@ describe('Tests for EventManager application\n', () => {
           token: adminToken,
         })
         .end((err, res) => {
-          expect(res).to.have.status(406);
+          expect(res).to.have.status(409);
           expect(res.body).to.have.property('message').to.include('Same center already exists');
           done();
         });

--- a/server/tests/3 eventRouterTests.js
+++ b/server/tests/3 eventRouterTests.js
@@ -27,7 +27,7 @@ describe('Tests for EventManager application\n', () => {
           done();
         });
     });
-    it('Should test for addEvents 406 response', (done) => {
+    it('Should test for addEvents 409 response', (done) => {
       chai.request(app)
         .post('/api/v1/events')
         .send({
@@ -39,7 +39,7 @@ describe('Tests for EventManager application\n', () => {
           token: userToken,
         })
         .end((err, res) => {
-          expect(res).to.have.status(406);
+          expect(res).to.have.status(409);
           expect(res.body.message).to.have.property('Sorry').to.contain('Selected date is already occupied for centerId: 1');
           expect(res.body.message.OccupiedDates).to.be.an('array');
           done();
@@ -62,7 +62,7 @@ describe('Tests for EventManager application\n', () => {
           done();
         });
     });
-    it('Should test for modifyEvent 406 response', (done) => {
+    it('Should test for modifyEvent 409 response', (done) => {
       chai.request(app)
         .put('/api/v1/events/1')
         .send({
@@ -74,7 +74,7 @@ describe('Tests for EventManager application\n', () => {
           token: userToken,
         })
         .end((err, res) => {
-          expect(res).to.have.status(406);
+          expect(res).to.have.status(409);
           expect(res.body.message).to.have.property('Sorry').to.contain('Selected date is already occupied for centerId: 1');
           expect(res.body.message.OccupiedDates).to.be.an('array');
           done();

--- a/server/util.js
+++ b/server/util.js
@@ -53,7 +53,7 @@ export function compareCenters(req, res, centersToCompare, nextAction) {
     });
   }
   if (sameCenter) {
-    return errorResponseWithCloudinary(req, res, 406, sameCenter);
+    return errorResponseWithCloudinary(req, res, 409, sameCenter);
   }
   return nextAction();
 }
@@ -125,7 +125,7 @@ export function checkAvailability(req, res, timestamp, events) {
     }
   });
   if (errorMessage) {
-    return errorResponseWithCloudinary(req, res, 406, errorMessage);
+    return errorResponseWithCloudinary(req, res, 409, errorMessage);
   }
   return true;
 }


### PR DESCRIPTION
#### What does this PR do?
Implement server side feedback from LF

#### Description of Task to be completed?
1. Remove password field in signup json response
2. When a regular user tries to update a center, validate account type first, before checking for already existing center
3. Limit array of events returned when retrieving a single center
4. Replace all 406 (Not acceptable) error response status codes to more suitable 409
5. Resolve event update error (request was not returning a response after previous feedback was implemented)
6. Error response messages should be more descriptive

#### How should this be manually tested?
1. On terminal, run command: `npm run start:dev`
2. On postman, test all routes to ensure features were implemented without breaking code

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories? (If applicable)
[#158759549](https://www.pivotaltracker.com/story/show/158759549)

#### Screenshots (If applicable)
N/A